### PR TITLE
Add Arduino firmware build simulation workflow

### DIFF
--- a/.github/workflows/arduino-sim.yml
+++ b/.github/workflows/arduino-sim.yml
@@ -28,8 +28,8 @@ jobs:
           arduino-cli compile --fqbn arduino:avr:mega --build-path build \
             --libraries Arduino/Libraries \
             Arduino/Firmware-ardunok/Firmware-ardunok.ino | tee build.log
-          used=$(grep "Global variables use" build.log | awk '{print $5}')
-          max=$(grep "Global variables use" build.log | awk '{print $10}')
+          used=$(grep -oP 'Global variables use \K\d+' build.log)
+          max=$(grep -oP 'Global variables use.*Maximum is \K\d+' build.log)
           percent=$((used * 100 / max))
           echo "Dynamic memory usage: ${percent}%"
           {

--- a/.github/workflows/arduino-sim.yml
+++ b/.github/workflows/arduino-sim.yml
@@ -20,20 +20,33 @@ jobs:
           arduino-cli core install arduino:avr
       - name: Compile firmware and check memory
         run: |
-          set -e
+          set -euo pipefail
           arduino-cli compile --fqbn arduino:avr:mega --build-path build Arduino/Firmware-ardunok/Firmware-ardunok.ino | tee build.log
           used=$(grep "Global variables use" build.log | awk '{print $5}')
           max=$(grep "Global variables use" build.log | awk '{print $10}')
           percent=$((used * 100 / max))
           echo "Dynamic memory usage: ${percent}%"
+          {
+            echo "### Build report";
+            echo "* Dynamic memory usage: ${percent}% (${used} of ${max} bytes)";
+          } >> "$GITHUB_STEP_SUMMARY"
           if [ "$percent" -ge 95 ]; then
             echo "Memory usage exceeds safe threshold"
             exit 1
           fi
       - name: Run AVR simulation
         run: |
+          set -euo pipefail
           sudo apt-get update && sudo apt-get install -y simavr
-          simavr -m atmega2560 -f 16000000 build/Firmware-ardunok.ino.elf &
-          pid=$!
-          sleep 5
-          kill $pid || true
+          test -f build/Firmware-ardunok.ino.elf
+          if ! timeout 5s simavr -m atmega2560 -f 16000000 build/Firmware-ardunok.ino.elf; then
+            status=$?
+            if [ "$status" -ne 124 ]; then
+              echo "simavr failed"
+              exit "$status"
+            fi
+          fi
+          {
+            echo "### Simulation";
+            echo "* simavr ran for 5 seconds";
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/arduino-sim.yml
+++ b/.github/workflows/arduino-sim.yml
@@ -1,0 +1,38 @@
+name: Arduino build and simulate
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install arduino-cli
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$HOME/bin sh
+          echo "$HOME/bin" >> $GITHUB_PATH
+      - name: Set up Arduino core
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install arduino:avr
+      - name: Compile firmware and check memory
+        run: |
+          set -e
+          arduino-cli compile --fqbn arduino:avr:mega --build-path build Arduino/Firmware-ardunok/Firmware-ardunok.ino | tee build.log
+          used=$(grep "Global variables use" build.log | awk '{print $5}')
+          max=$(grep "Global variables use" build.log | awk '{print $10}')
+          percent=$((used * 100 / max))
+          echo "Dynamic memory usage: ${percent}%"
+          if [ "$percent" -ge 95 ]; then
+            echo "Memory usage exceeds safe threshold"
+            exit 1
+          fi
+      - name: Run AVR simulation
+        run: |
+          sudo apt-get update && sudo apt-get install -y simavr
+          simavr -m atmega2560 -f 16000000 build/Firmware-ardunok.ino.elf &
+          pid=$!
+          sleep 5
+          kill $pid || true

--- a/.github/workflows/arduino-sim.yml
+++ b/.github/workflows/arduino-sim.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install arduino-cli
         run: |
+          mkdir -p "$HOME/bin"
           curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$HOME/bin sh
           echo "$HOME/bin" >> $GITHUB_PATH
       - name: Set up Arduino core

--- a/.github/workflows/arduino-sim.yml
+++ b/.github/workflows/arduino-sim.yml
@@ -18,10 +18,16 @@ jobs:
         run: |
           arduino-cli core update-index
           arduino-cli core install arduino:avr
+      - name: Install Arduino libraries
+        run: |
+          arduino-cli lib update-index
+          arduino-cli lib install "Adafruit GFX Library" "Adafruit PCD8544 Nokia 5110 LCD library"
       - name: Compile firmware and check memory
         run: |
           set -euo pipefail
-          arduino-cli compile --fqbn arduino:avr:mega --build-path build Arduino/Firmware-ardunok/Firmware-ardunok.ino | tee build.log
+          arduino-cli compile --fqbn arduino:avr:mega --build-path build \
+            --libraries Arduino/Libraries \
+            Arduino/Firmware-ardunok/Firmware-ardunok.ino | tee build.log
           used=$(grep "Global variables use" build.log | awk '{print $5}')
           max=$(grep "Global variables use" build.log | awk '{print $10}')
           percent=$((used * 100 / max))

--- a/Tools/build-and-simulate.sh
+++ b/Tools/build-and-simulate.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+SKETCH="Arduino/Firmware-ardunok/Firmware-ardunok.ino"
+FQBN="arduino:avr:mega"
+BUILD_DIR="build"
+
+arduino-cli core update-index
+arduino-cli core install arduino:avr
+arduino-cli compile --fqbn "$FQBN" --build-path "$BUILD_DIR" "$SKETCH" | tee build.log
+
+used=$(grep "Global variables use" build.log | awk '{print $5}')
+max=$(grep "Global variables use" build.log | awk '{print $10}')
+percent=$((used * 100 / max))
+echo "Dynamic memory usage: ${percent}%"
+if [ "$percent" -ge 95 ]; then
+  echo "Memory usage exceeds safe threshold"
+  exit 1
+fi
+
+if command -v simavr >/dev/null 2>&1; then
+  simavr -m atmega2560 -f 16000000 "$BUILD_DIR/Firmware-ardunok.ino.elf" &
+  pid=$!
+  sleep 5
+  kill $pid || true
+else
+  echo "simavr not installed; skipping simulation"
+fi

--- a/Tools/build-and-simulate.sh
+++ b/Tools/build-and-simulate.sh
@@ -13,8 +13,8 @@ arduino-cli lib install "Adafruit GFX Library" "Adafruit PCD8544 Nokia 5110 LCD 
 
 arduino-cli compile --fqbn "$FQBN" --build-path "$BUILD_DIR" --libraries "$LIB_DIR" "$SKETCH" | tee build.log
 
-used=$(grep "Global variables use" build.log | awk '{print $5}')
-max=$(grep "Global variables use" build.log | awk '{print $10}')
+used=$(grep -oP 'Global variables use \K\d+' build.log)
+max=$(grep -oP 'Global variables use.*Maximum is \K\d+' build.log)
 percent=$((used * 100 / max))
 echo "Dynamic memory usage: ${percent}%"
 if [ "$percent" -ge 95 ]; then

--- a/Tools/build-and-simulate.sh
+++ b/Tools/build-and-simulate.sh
@@ -4,10 +4,14 @@ set -euo pipefail
 SKETCH="Arduino/Firmware-ardunok/Firmware-ardunok.ino"
 FQBN="arduino:avr:mega"
 BUILD_DIR="build"
+LIB_DIR="Arduino/Libraries"
 
 arduino-cli core update-index
 arduino-cli core install arduino:avr
-arduino-cli compile --fqbn "$FQBN" --build-path "$BUILD_DIR" "$SKETCH" | tee build.log
+arduino-cli lib update-index
+arduino-cli lib install "Adafruit GFX Library" "Adafruit PCD8544 Nokia 5110 LCD library"
+
+arduino-cli compile --fqbn "$FQBN" --build-path "$BUILD_DIR" --libraries "$LIB_DIR" "$SKETCH" | tee build.log
 
 used=$(grep "Global variables use" build.log | awk '{print $5}')
 max=$(grep "Global variables use" build.log | awk '{print $10}')

--- a/Tools/build-and-simulate.sh
+++ b/Tools/build-and-simulate.sh
@@ -19,10 +19,17 @@ if [ "$percent" -ge 95 ]; then
 fi
 
 if command -v simavr >/dev/null 2>&1; then
-  simavr -m atmega2560 -f 16000000 "$BUILD_DIR/Firmware-ardunok.ino.elf" &
-  pid=$!
-  sleep 5
-  kill $pid || true
+  if [ ! -f "$BUILD_DIR/Firmware-ardunok.ino.elf" ]; then
+    echo "Firmware ELF not found"
+    exit 1
+  fi
+  if ! timeout 5s simavr -m atmega2560 -f 16000000 "$BUILD_DIR/Firmware-ardunok.ino.elf"; then
+    status=$?
+    if [ "$status" -ne 124 ]; then
+      echo "Simulation failed"
+      exit "$status"
+    fi
+  fi
 else
   echo "simavr not installed; skipping simulation"
 fi


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to compile firmware with arduino-cli
- check dynamic memory usage and simulate firmware using simavr
- provide local script to run the same build and simulation steps

## Testing
- `Tools/build-and-simulate.sh` *(fails: `arduino-cli: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68b646e100f48329b1357fc164f207a5